### PR TITLE
fixed url for help with downloading public datasets. 

### DIFF
--- a/components/DownloadDataset/DownloadDataset.vue
+++ b/components/DownloadDataset/DownloadDataset.vue
@@ -41,7 +41,7 @@
           Raw files and metadata are stored in an AWS S3 Requester Pays bucket.
           You can learn more about
           <a
-            href="https://help.blackfynn.com/en/articles/3359427"
+            href="https://docs.pennsieve.io/docs/downloading-a-public-dataset"
             target="_blank"
           >
             downloading data from AWS


### PR DESCRIPTION

# Description

fixed url for help with downloading public datasets.  Now points to Pennsieve resource instead of Blackfynn resources.

## Clickup Ticket

https://app.clickup.com/t/20qmf3x


## Type of change

_Delete those that don't apply._

- [ x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on local instance of the app. Please verify



