### PR TITLE
Changed social media links

### DIFF
--- a/components/DatasetDetails/DatasetDetails.vue
+++ b/components/DatasetDetails/DatasetDetails.vue
@@ -397,7 +397,13 @@ export default {
      * @returns {String}
      */
     siteUrl() {
-      return process.env.siteUrl
+      let ShareUrl = process.env.siteUrl
+      ShareUrl += '/datasets/'
+      const ShareID = propOr(0, 'id', this.datasetDetails)
+      const ShareID2 = String(ShareID)
+      ShareUrl += ShareID2
+
+      return ShareUrl
     },
 
     /**

--- a/components/DatasetDetails/DatasetDetails.vue
+++ b/components/DatasetDetails/DatasetDetails.vue
@@ -400,9 +400,12 @@ export default {
       let ShareUrl = process.env.siteUrl
       ShareUrl += '/datasets/'
       const ShareID = propOr(0, 'id', this.datasetDetails)
+      const ShareVersion = prop('version', this.datasetDetails)
+      const ShareVersion2 = String(ShareVersion)
       const ShareID2 = String(ShareID)
       ShareUrl += ShareID2
-
+      ShareUrl += '/version/'
+      ShareUrl += ShareVersion2
       return ShareUrl
     },
 

--- a/set_env_vars.sh
+++ b/set_env_vars.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+export DEPLOY_ENV=development
+export discover_api_host=https://api.pennsieve.net/discover
+export HOST=0.0.0.0
+export MAX_DOWNLOAD_SIZE=5000000000
+export NODE_ENV=development
+export NPM_CONFIG_PRODUCTION=false
+export PENNSIEVE_API_HOST=https://api.pennsieve.net
+export PENNSIEVE_DISCOVER_API_HOST=https://api.pennsieve.net/discover
+export PENNSIEVE_ZIPIT_HOST=https://api.pennsieve.net/zipit/discover
+export REGION=us-east-1
+export SITE_URL=https://discover.pennsieve.net
+export USER_POOL_ID=us-east-1_XciE1JSvP
+export USER_POOL_WEB_CLIENT_ID=2653f5r4vgk8eo1p17nvaftaea


### PR DESCRIPTION
# Description

updated social media share links to point to specific dataset and version as opposed to the pennsieve discover landing page


## Clickup Ticket

https://app.clickup.com/t/xfacd9


## Type of change

_Delete those that don't apply._

- [x ] Bug fix (non-breaking change which fixes an issue)



# How Has This Been Tested?

Local app tests. Please test functionality on development branch


