### PR TITLE
Fix outdated login dialog links

### DIFF
--- a/components/shared/BfLogInDialog/BfLogInDialog.vue
+++ b/components/shared/BfLogInDialog/BfLogInDialog.vue
@@ -52,9 +52,7 @@
               >Forgot Password?</a
             >
             |
-            <a href="https://docs.pennsieve.io" target="_blank"
-              >Learn More</a
-            >
+            <a href="https://docs.pennsieve.io" target="_blank">Learn More</a>
           </div>
         </template>
         <template v-else-if="isForgotPasswordState">

--- a/components/shared/BfLogInDialog/BfLogInDialog.vue
+++ b/components/shared/BfLogInDialog/BfLogInDialog.vue
@@ -52,7 +52,7 @@
               >Forgot Password?</a
             >
             |
-            <a href="https://www.blackfynn.com/academia/" target="_blank"
+            <a href="https://docs.pennsieve.io" target="_blank"
               >Learn More</a
             >
           </div>
@@ -104,7 +104,7 @@
           <a
             class="log-in-dialog__container--actions"
             :class="actionsClass"
-            href="https://help.blackfynn.com/en/"
+            href="https://docs.pennsieve.io"
             target="_blank"
             >Need Help?</a
           >
@@ -113,14 +113,14 @@
           By signing in to Pennsieve, you accept our
           <a
             class="grey-link"
-            href="https://www.blackfynn.com/terms"
+            href="https://docs.pennsieve.io/page/pennsieve-terms-of-use"
             target="_blank"
             >Terms of Use</a
           >
           and
           <a
             class="grey-link"
-            href="https://www.blackfynn.com/privacy/"
+            href="https://docs.pennsieve.io/page/privacy-policy"
             target="_blank"
             >Privacy Policy</a
           >.

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -56,7 +56,7 @@ export default {
     userPoolWebClientId:
       process.env.USER_POOL_WEB_CLIENT_ID || '703lm5d8odccu21pagcfjkeaea',
     authenticationFlowType:
-      process.env.AUTHENTICATION_FLOW_TYPE || 'USER_PASSWORD_AUTH',
+      process.env.AUTHENTICATION_FLOW_TYPE || 'USER_PASSWORD_AUTH'
   },
   /*
    ** Customize the progress-bar color


### PR DESCRIPTION
# Description

Several links on the login dialog were outdated. This change updates those links to point to the correct Pennsieve docs pages.

One of the pages now linked to by this change is [Pennsieve Terms of Use](https://docs.pennsieve.io/page/pennsieve-terms-of-use). This terms of use page actually only explicitly mentions https://app.pennsieve.io and not https://discover.pennsieve.io and so might need to be updated since this change now points Discover users there as well.


## Clickup Ticket

[Link to Learn More in discover is incorrect](https://app.clickup.com/t/20x7p84)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change possibly requires a documentation update


# How Has This Been Tested?

Checked links by running locally.

