### PR TITLE
Data Use Agreement: render formatted text and Markdown properly

### DIFF
--- a/components/DataUseAgreementSignDialog/DataUseAgreementSignDialog.vue
+++ b/components/DataUseAgreementSignDialog/DataUseAgreementSignDialog.vue
@@ -9,7 +9,12 @@
 
     <div class="bf-dialog-body">
       <div class="agreement-wrap">
-        {{ dataUseAgreement.body }}
+        <!-- eslint-disable vue/no-v-html -->
+        <!-- $sanitize will sanitize the HTML injected -->
+        <div
+          class="col-xs-12 col-md-8 description-container"
+          v-html="parsedMarkdown"
+        />
       </div>
     </div>
 
@@ -50,6 +55,11 @@
 <script>
 import BfButton from '@/components/shared/BfButton/BfButton'
 import BfDialogHeader from '@/components/shared/BfDialogHeader/BfDialogHeader.vue'
+import marked from 'marked'
+
+marked.setOptions({
+  sanitize: true
+})
 
 export default {
   name: 'DataUseAgreementSignDialog',
@@ -79,7 +89,8 @@ export default {
   data() {
     return {
       isAgreementChecked: false,
-      isProcessing: false
+      isProcessing: false,
+      marked
     }
   },
 
@@ -92,7 +103,18 @@ export default {
       return this.isSigningAgreement
         ? 'Sign Data Use Agreement'
         : this.dataUseAgreement.name
-    }
+    },
+
+    /**
+     * Parses the markdown text
+     */
+    parsedMarkdown() {
+      return marked(this.dataUseAgreementBody)
+    },
+
+    dataUseAgreementBody() {
+      return this.replaceAllSlashEscapedSequences(this.dataUseAgreement.body)
+    },
   },
 
   methods: {
@@ -126,12 +148,39 @@ export default {
     download() {
       this.isProcessing = true
       this.$emit('download', this.dataUseAgreement.id)
+    },
+
+    replaceAllSlashEscapedSequences(sourceString){
+      var result = ''
+      var remaining = sourceString
+      var cutPoint = 0
+
+      var index = remaining.indexOf("\\")
+      while (index >= 0){
+        var nextChar = remaining[index+1]
+        var append = ''
+        if (nextChar === 'n') {
+          append = '\n'
+        } else if (nextChar === 't') {
+          append = '\t'
+        }
+        var slice = remaining.slice(cutPoint,index)
+        result = result.concat(slice)
+        result = result.concat(append)
+        remaining = remaining.slice(index+2)
+        index = remaining.indexOf("\\")
+      }
+      if (remaining.length > 0) {
+        result = result.concat(remaining)
+      }
+      return result
     }
   }
 }
 </script>
 
 <style lang="scss" scoped>
+@import '../../assets/css/_variables.scss';
 /deep/ .el-dialog {
   display: flex;
   flex-direction: column;
@@ -146,5 +195,100 @@ export default {
 }
 .button-wrap {
   display: flex;
+}
+
+// Markdown styles
+.description-container {
+  color: #000;
+  font-size: 16px;
+  line-height: 24px;
+  padding-top: 32px;
+  white-space: pre-wrap;
+
+  ::v-deep {
+    h1,
+    p,
+    h2,
+    h3,
+    blockquote,
+    h4,
+    pre {
+      max-width: 616px;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5 {
+      margin: 0 0 8px;
+    }
+
+    h1 {
+      font-size: 32px;
+      font-weight: bold;
+      line-height: 40px;
+    }
+
+    p {
+      margin-bottom: 16px;
+    }
+
+    img {
+      height: auto;
+      max-width: 170%;
+      margin-bottom: 20px;
+      flex-basis: 50%;
+      margin-top: 24px;
+    }
+
+    h2 {
+      font-size: 24px;
+      font-weight: bold;
+      line-height: 32px;
+    }
+
+    h3 {
+      font-size: 20px;
+      font-weight: bold;
+      line-height: 24px;
+      letter-spacing: 0px;
+    }
+
+    h4 {
+      font-size: 16px;
+      font-weight: bold;
+      line-height: 24px;
+      text-transform: uppercase;
+      letter-spacing: 0px;
+    }
+
+    ul {
+      margin: 0 0 16px;
+      padding: 0 0 0 18px;
+    }
+
+    blockquote {
+      font-weight: normal;
+      line-height: 24px;
+      font-size: 16px;
+      border-left: 8px solid $dopamine-dark;
+      margin-left: 0;
+
+      p {
+        margin-left: 16px;
+      }
+    }
+    pre {
+      background-color: #f1f1f3;
+      line-height: 24px;
+      padding: 16px;
+
+      code {
+        font-weight: normal;
+        font-size: 14px;
+      }
+    }
+  }
 }
 </style>


### PR DESCRIPTION
Data Use Agreement: render formatted text and Markdown properly

# Description

- Change to use **marked** package to render Markdown.
- Change to replace escaped newline and tab sequences with non-escaped (\\n -> \n, \\t -> \t)


## Clickup Ticket

[CLICKUP | Fix formatting for data use agreement on Discover](https://app.clickup.com/t/u5d71b)


## Type of change

_Delete those that don't apply._

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

locally, and to be tested on Non-prod environment


# Checklist:

_Delete those that don't apply. Only apply the final commit message using the changelog when merging a feature to `DEVELOPMENT` that will be deployed to all users._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have pushed the final commit message using the [changelog format](https://github.com/Blackfynn/blackfynn-app/wiki/CHANGELOG)
