### PR TITLE
Fix: check for undefined before replacing slash-escaped sequences

### DIFF
--- a/components/DataUseAgreementSignDialog/DataUseAgreementSignDialog.vue
+++ b/components/DataUseAgreementSignDialog/DataUseAgreementSignDialog.vue
@@ -58,7 +58,7 @@ import BfDialogHeader from '@/components/shared/BfDialogHeader/BfDialogHeader.vu
 import marked from 'marked'
 
 marked.setOptions({
-  sanitize: true
+  gfm: true
 })
 
 export default {
@@ -153,26 +153,29 @@ export default {
     replaceAllSlashEscapedSequences(sourceString){
       var result = ''
       var remaining = sourceString
-      var cutPoint = 0
 
-      var index = remaining.indexOf("\\")
-      while (index >= 0){
-        var nextChar = remaining[index+1]
-        var append = ''
-        if (nextChar === 'n') {
-          append = '\n'
-        } else if (nextChar === 't') {
-          append = '\t'
+      if (remaining) {
+        var cutPoint = 0
+        var index = remaining.indexOf("\\")
+        while (index >= 0){
+          var nextChar = remaining[index+1]
+          var append = ''
+          if (nextChar === 'n') {
+            append = '\n'
+          } else if (nextChar === 't') {
+            append = '\t'
+          }
+          var slice = remaining.slice(cutPoint,index)
+          result = result.concat(slice)
+          result = result.concat(append)
+          remaining = remaining.slice(index+2)
+          index = remaining.indexOf("\\")
         }
-        var slice = remaining.slice(cutPoint,index)
-        result = result.concat(slice)
-        result = result.concat(append)
-        remaining = remaining.slice(index+2)
-        index = remaining.indexOf("\\")
+        if (remaining.length > 0) {
+          result = result.concat(remaining)
+        }
       }
-      if (remaining.length > 0) {
-        result = result.concat(remaining)
-      }
+
       return result
     }
   }


### PR DESCRIPTION
# Description

Check whether string is undefined before replacing slash-escaped sequences in Data Use Agreement formatting.


## Clickup Ticket

[CLICKUP_TICKET](https://app.clickup.com/t/2n9j83k)


## Type of change

_Delete those that don't apply._

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

locally


# Checklist:

_Delete those that don't apply. Only apply the final commit message using the changelog when merging a feature to `DEVELOPMENT` that will be deployed to all users._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have pushed the final commit message using the [changelog format](https://github.com/Blackfynn/blackfynn-app/wiki/CHANGELOG)
