### PR TITLE
Update API request by removing auth token

### DIFF
--- a/components/RehydrationModal/RehydrationModal.vue
+++ b/components/RehydrationModal/RehydrationModal.vue
@@ -156,7 +156,7 @@ export default {
 
       // make API call the rehydration endpoint
       // replace with config.env.api_host
-      const url = `https://api2.pennsieve.net/rehydrate/?api_key=${this.userToken}`
+      const url = `https://api2.pennsieve.net/rehydrate`
       // TODO: don't forget to change this to pull from the ENV instead of being hard coded.
 
       this.sendXhr(url, {


### PR DESCRIPTION
# Description

API is being updated to not require auth, so I updated the API integration to remove the token being appended. I was appending it in the wrong way for an api2 endpoint, also - API2 endpoints do not take the token as a query param, you have to pass it in the body. 

Here is an example of an API2 integration (with auth) that is done correctly, for future reference: 

https://github.com/Pennsieve/pennsieve-app/blob/main/src/components/datasets/files/custom-actions-dialog/CustomActionsDialog.vue#L6C24-L251C5
