### PR TITLE
update endpoint url to include /discover/

### DIFF
--- a/components/RehydrationModal/RehydrationModal.vue
+++ b/components/RehydrationModal/RehydrationModal.vue
@@ -156,7 +156,7 @@ export default {
 
       // make API call the rehydration endpoint
       // replace with config.env.api_host
-      const url = `https://api2.pennsieve.net/rehydrate`
+      const url = `https://api2.pennsieve.net/discover/rehydrate`
       // TODO: don't forget to change this to pull from the ENV instead of being hard coded.
 
       this.sendXhr(url, {


### PR DESCRIPTION
# Description

endpoint was changed to be /discover/rehydrate instead of just /rehydrate so I updated the url in the FE integration to reflect this. 
