### PR TITLE
Feature rehydration form add toast messages

### DIFF
--- a/assets/css/components/_el-message.scss
+++ b/assets/css/components/_el-message.scss
@@ -51,3 +51,10 @@
     opacity: .7
   }
 }
+
+.el-message.request-submitted {
+  box-sizing: border-box;
+  max-width: 600px;
+  top: 130px !important;
+  width: 100%;
+}

--- a/assets/css/components/_el-message.scss
+++ b/assets/css/components/_el-message.scss
@@ -20,7 +20,10 @@
     }
   }
   &.el-message--error {
-    background: $error-color
+    background: $error-color;
+    .el-message__content {
+      color: #fff;
+    }
   }
   &.el-message--info {
     background: $notification-color;

--- a/components/DatasetHeader/DatasetHeader.vue
+++ b/components/DatasetHeader/DatasetHeader.vue
@@ -800,11 +800,3 @@ export default {
   margin-top: 32px;
 }
 </style>
-<style lang="scss">
-.el-message.request-submitted {
-  box-sizing: border-box;
-  max-width: 600px;
-  top: 115px !important;
-  width: 100%;
-}
-</style>

--- a/components/RehydrationModal/RehydrationModal.vue
+++ b/components/RehydrationModal/RehydrationModal.vue
@@ -61,6 +61,7 @@ import { pathOr } from 'ramda'
 import BfButton from '../shared/BfButton/BfButton.vue'
 import BfDialogHeader from '../shared/BfDialogHeader/BfDialogHeader.vue'
 import Request from '@/mixins/request'
+import EventBus from '@/utils/event-bus'
 
 export default {
   name: 'RehydrationModal',
@@ -179,10 +180,24 @@ export default {
             recaptchaToken: recaptchaToken
           }
         })
-        // when the API call is successful, make a toast pop up that tells the user that the request has been successful.
+        this.closeDialog()
+        EventBus.$emit('toast', {
+            detail: {
+              msg: `Your request has been successfully submitted.`,
+              type: 'SUCCESS',
+              class: 'request-submitted'
+            }
+          })
       } catch (error) {
         this.clearForm()
         this.closeDialog()
+        EventBus.$emit('toast', {
+            detail: {
+              msg: `Failed to submit the request`,
+              type: 'ERROR',
+              class: 'request-submitted'
+            }
+          })
         // Make a toast that tells the user there is an error pop up here
       }
     },


### PR DESCRIPTION
# Description

- Display status toast/notification when a rehydration request is submitted

## Clickup Ticket

[CLICKUP_TICKET](https://app.clickup.com/t/8687j8vbk)


## Type of change

_Delete those that don't apply._

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Tested success flow/status-notification by submitting a valid rehydration request. UI displays success toast upon request submission.
- Tested failure flow/status-notification by manipulating the URL locally (to point to an non-existant endpoint) OR blocked the network request in browser devtools to replicate a network error. UI Displays failure toast upon network/api failure.


# Checklist:

_Delete those that don't apply. Only apply the final commit message using the changelog when merging a feature to `DEVELOPMENT` that will be deployed to all users._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
