### PR TITLE
fix recaptcha badge display logic

### DIFF
--- a/components/RehydrationModal/RehydrationModal.vue
+++ b/components/RehydrationModal/RehydrationModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <el-dialog :visible="visible" :show-close="false" @close="closeDialog">
+  <el-dialog :visible="visible" :show-close="false" @close="closeDialog" @open="intializeReacaptcha">
     <bf-dialog-header slot="title" title="Request Rehydration" />
     <div class="rehydration-modal-container">
       <div class="copy-container">
@@ -129,11 +129,6 @@ export default {
 
   async mounted() {
     this.authenticatedUserEmail = pathOr('', ['email'], this.profile)
-    try {
-      await this.$recaptcha.init();
-    } catch (e) {
-      console.error(e);
-    }
   },
 
   methods: {
@@ -150,7 +145,8 @@ export default {
       if(!this.isUserAuthenticated) {
         this.clearForm();
       }
-      this.$emit('close-rehydration-dialog')
+      this.$emit('close-rehydration-dialog');
+      this.$recaptcha.destroy();
     },
     onFormSubmit() {
       if(this.isUserAuthenticated) {   
@@ -218,7 +214,9 @@ export default {
         console.error(error)
       }
     },
-
+    /**
+     * Error handler for request rehydration submission
+     */
     reqestRehydrationError() {
       EventBus.$emit('toast', {
             detail: {
@@ -227,12 +225,21 @@ export default {
               class: 'request-submitted'
             }
           })
-    }
+    },
+    /**
+    * initialize recaptcha background process
+    */
+    async intializeReacaptcha() {
+        try {
+        await this.$recaptcha.init();
+        } catch (e) {
+          console.error(e);
+        }
+     },
   },
 
   beforeDestroy() {
     EventBus.$off('ajaxError', this.reqestRehydrationError.bind(this))
-    this.$recaptcha.destroy()
   }
 }
 </script>


### PR DESCRIPTION
# Description

- refactor logic to trigger recaptcha process
- this change allows to display recaptcha badge only when the form is rendered in the UI

## Clickup Ticket

[CLICKUP_TICKET](https://app.clickup.com/t/8687j8vbk)


## Type of change

_Delete those that don't apply._

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
- ReCAPTCHA badge should be displayed only when the rehydration request form is displayed on the screen, otherwise it should not be displayed on the page. The badge is displayed on the bottom right of the page to indicate ReCAPTCHA background process

# Checklist:

_Delete those that don't apply. Only apply the final commit message using the changelog when merging a feature to `DEVELOPMENT` that will be deployed to all users._

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
